### PR TITLE
Distinguish pos/morph for XML import/export (resolves #82)

### DIFF
--- a/doc/user/layers.md
+++ b/doc/user/layers.md
@@ -70,10 +70,13 @@ internally**, and actually represent a single annotation of the value
 In a tag value, everything preceding the first dot is considered to be the
 (base) "POS" tag, while everything following it is treated as belonging to
 "Morphology".  An exception is made for tags having a single dot at the end,
-because some tagsets use tags like "*$.*" for punctuation.  Note that you
-are *not required* to use morphological attributes in your tags --- it is
-perfectly fine to use tagsets with only plain POS tags; the "Morphology" column
-can be [conveniently hidden](doc-customize.md) in this case.
+because some tagsets use tags like "*$.*" for punctuation.
+When [exporting documents to XML](coraxml.md), POS tags are split up into "pos"
+and "morph" tags according to this rule.
+
+Note that you are *not required* to use morphological attributes in your tags
+--- it is perfectly fine to use tagsets with only plain POS tags; the
+"Morphology" column can be [conveniently hidden](doc-customize.md) in this case.
 
 ### Lemmatization
 

--- a/tests/backend/data/XMLHandler_test_expected.xml
+++ b/tests/backend/data/XMLHandler_test_expected.xml
@@ -15,16 +15,18 @@
     <mod ascii="" checked="y" id="t1_m1" trans="$ol|" utf="">
       <norm tag="sollst"/>
       <suggestions>
-        <pos score="0.91" source="user" tag="VVFIN.2.Sg.Pres.Ind"/>
+        <pos score="0.91" source="user" tag="VVFIN"/>
         <lemma source="user" tag="sollen"/>
+        <morph score="0.91" source="user" tag="2.Sg.Pres.Ind"/>
       </suggestions>
     </mod>
     <mod ascii="" checked="n" id="t1_m2" trans="tu" utf="">
       <norm tag="du"/>
       <comment tag="Interessantes Phänomen hier"/>
       <suggestions>
-        <pos score="0.91" source="user" tag="PPER.2.Sg.*.Nom"/>
+        <pos score="0.91" source="user" tag="PPER"/>
         <lemma source="user" tag="du"/>
+        <morph score="0.91" source="user" tag="2.Sg.*.Nom"/>
       </suggestions>
       <cora-flag name="boundary"/>
     </mod>
@@ -46,8 +48,9 @@
     <mod ascii="" checked="n" id="t3_m1" trans="Anshelm" utf="">
       <norm tag="Anselm"/>
       <suggestions>
-        <pos score="0.91" source="user" tag="NE.Masc.Nom.Sg"/>
+        <pos score="0.91" source="user" tag="NE"/>
         <lemma source="user" tag="Anselm"/>
+        <morph score="0.91" source="user" tag="Masc.Nom.Sg"/>
       </suggestions>
     </mod>
     <mod ascii="" checked="n" id="t3_m2" trans="/" utf="">

--- a/tests/backend/data/cora-importtest.xml
+++ b/tests/backend/data/cora-importtest.xml
@@ -81,7 +81,8 @@
         <mod id="t3_m1" ascii="Anshelm" utf="Anshelm" trans="Anshelm">
 	   <lemma tag="Anselm"/>
 	   <norm tag="Anselm"/>
-	   <pos tag="NE._._._"/>
+	   <pos tag="NE"/>
+           <morph tag="_._._"/>
             <suggestions></suggestions>
 	</mod>
 	<mod id="t3_m2" ascii="/" utf="/" trans="/">


### PR DESCRIPTION
Exporting to XML will now split up POS tags into "pos" and "morph".

Importing from XML will accept either the split "pos"/"morph" notation, or the single "pos" notation containing the full tag.