### PR TITLE
Don't redirect output to log file when calling import script

### DIFF
--- a/src/gui/js/file.js
+++ b/src/gui/js/file.js
@@ -519,6 +519,11 @@ cora.fileImporter = {
 		        if(status.done == "success") {
                             ref.resetImportForm(importform);
                             cora.projects.performUpdate();
+                            if (status.output) {
+                                gui.showTextDialog(_("FileTab.Forms.import.importSuccess"),
+                                                   _("FileTab.Forms.import.importSuccessInfo"),
+                                                   status.output);
+                            }
 			    gui.showNotice('ok', _("Banner.fileImportSuccess"));
 		        } else {
                             gui.showTextDialog(_("FileTab.Forms.import.importFailed"),
@@ -760,10 +765,10 @@ cora.fileImporter = {
 		status.done = 'success';
 	    } else {
 		status.done = 'error';
-		if(process.output != null) {
-		    status.message = _("FileTab.Forms.import.importError");
-                    status.output  = process.output;
-		}
+		status.message = _("FileTab.Forms.import.importError");
+           }
+	   if(process.output != null) {
+                status.output  = process.output;
 	    }
 	}
 	return status;

--- a/src/lib/commandHandler.php
+++ b/src/lib/commandHandler.php
@@ -117,7 +117,7 @@ class CommandHandler {
         $xmlfile = tempnam(sys_get_temp_dir(), 'cora');
         $output = array();
         $retval = 0;
-        $command = $this->options['cmd_import'] . " {$infile} {$xmlfile} >>{$logfile} 2>&1";
+        $command = $this->options['cmd_import'] . " {$infile} {$xmlfile} 2>&1";
         exec($command, $output, $retval);
         return $output;
     }

--- a/src/lib/sessionHandler.php
+++ b/src/lib/sessionHandler.php
@@ -322,10 +322,11 @@ class CoraSessionHandler {
         $errors = $ch->callImport($localname, $xmlname, $options['logfile']);
         $logfile = fopen($options['logfile'], 'a');
         if (!empty($errors)) {
-            fwrite($logfile, "~ERROR XML\n");
             fwrite($logfile, implode("\n", $errors) . "\n");
             fclose($logfile);
-            return false;
+            if (in_array("~ERROR CHECK", $errors) || in_array("~ERROR XML", $errors)) {
+                return false;
+            }
         }
         if (!isset($xmlname) || empty($xmlname)) {
             fwrite($logfile, "~ERROR XML\n");


### PR DESCRIPTION
Fixes #102 
The output of the script is added to the logfile [later](https://github.com/comphist/cora/blob/6b5d06589c7f3ce655f552fb8a863250d96cd4bf/src/lib/sessionHandler.php#L326) so redirecting it is not necessary.